### PR TITLE
Add ipv4 localhost to /etc/hosts

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: nephelaiio
 name: patroni
-version: 0.2.7
+version: 0.2.8
 readme: README.md
 authors:
   - Ted Cook <358176+teddyphreak@users.noreply.github.com>

--- a/playbooks/prepare.yml
+++ b/playbooks/prepare.yml
@@ -15,7 +15,7 @@
       ansible.builtin.lineinfile:
         path: /etc/hosts
         regexp: ".*{{ item }}.*"
-        line: "{{ _member_address }} {{ _fqdn }} {{ _hostname }}"
+        line: "{{ _member_address }} {{ _fqdn }} {{ _hostname }} localhost"
       vars:
         _member_address: "{{ hostvars[item]['ansible_default_ipv4']['address'] }}"
         _fqdn: "{{ hostvars[item]['ansible_fqdn'] }}"


### PR DESCRIPTION
Without this fix, /etc/hosts breaks IPv4 localhost resolution. When bootstrapping the cluster, the role waits for Patroni's health endpoint but tries to reach it via IPv6 localhost—where Patroni isn't listening. This creates an infinite wait condition.